### PR TITLE
docs: add content to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,5 +62,5 @@ script.
 [microsoft/vscode-dev-containers]: https://github.com/microsoft/vscode-dev-containers#readme
 [devcontainers-community#1]: https://github.com/orgs/devcontainers-community/discussions/1
 [discussion]: https://github.com/devcontainers-community/templates/discussions
-[contributing guide]: https://github.com/devcontainers-community/blob/main/CONTRIBUTING.md
+[contributing guide]: https://github.com/devcontainers-community/templates/blob/main/CONTRIBUTING.md
 <!-- prettier-ignore-end -->

--- a/README.md
+++ b/README.md
@@ -34,4 +34,28 @@ unofficial templates!
 
 </div>
 
+## Development
+
+🐣 The [@devcontainers-community] organization is still in its early stages.
+This template repository is currently limited in scope. We are **only adding
+popular templates from [microsoft/vscode-dev-containers]** for now. You can find
+more information about [@devcontainers-community]'s goals and plans in
+[devcontainers-community#1]. If you notice a bug 🐛 or have an improvement
+suggestion 💡 we'd love to hear it! 😍
+
+If you're interested in getting started modifying, adding, or testing a template
+in this repository, you can do so without even leaving your browser thanks to
+GitHub Codespaces! ☁️ After optionally forking the repository, you just hit the
+green <kbd>Code</kbd> button at the top of the GitHub web UI and then
+<kbd>Create codespace on main</kbd>. 🚀
+
+After launching your dev environment and making some changes, you're probably
+going to want to test those changes. To do so, you can run the `tools/test.sh`
+script.
+
+<!-- prettier-ignore-start -->
 [@devcontainers]: https://github.com/devcontainers
+[@devcontainers-community]: https://github.com/devcontainers-community
+[microsoft/vscode-dev-containers]: https://github.com/microsoft/vscode-dev-containers#readme
+[devcontainers-community#1]: https://github.com/orgs/devcontainers-community/discussions/1
+<!-- prettier-ignore-end -->

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ unofficial templates!
 
 ## Development
 
+![Devcontainers](https://img.shields.io/static/v1?style=for-the-badge&message=Devcontainers&color=2496ED&logo=Docker&logoColor=FFFFFF&label=)
+![Bash](https://img.shields.io/static/v1?style=for-the-badge&message=Bash&color=4EAA25&logo=GNU+Bash&logoColor=FFFFFF&label=)
+
 🐣 The [@devcontainers-community] organization is still in its early stages.
 This template repository is currently limited in scope. We are **only adding
 popular templates from [microsoft/vscode-dev-containers]** for now. You can find
@@ -51,4 +54,5 @@ script.
 [@devcontainers-community]: https://github.com/devcontainers-community
 [microsoft/vscode-dev-containers]: https://github.com/microsoft/vscode-dev-containers#readme
 [devcontainers-community#1]: https://github.com/orgs/devcontainers-community/discussions/1
+[discussion]: https://github.com/devcontainers-community/templates/discussions
 <!-- prettier-ignore-end -->

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <div align="center">
 
-![](https://i.imgur.com/NSfVKbP.png)
+![](https://i.imgur.com/Us84cLP.png)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@
 
 🔧 80% of the configuration you'll ever need \
 💻 Ready to go with GitHub Codespaces \
-🚀 Quickly get up-and-running with a devcontainer \
-🐳 No need to mess with a `Dockerfile`
+🚀 Quickly get up-and-running with a devcontainer
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -54,10 +54,13 @@ After launching your dev environment and making some changes, you're probably
 going to want to test those changes. To do so, you can run the `tools/test.sh`
 script.
 
+🤝 Check out our [contributing guide] to see how to get your changes merged!
+
 <!-- prettier-ignore-start -->
 [@devcontainers]: https://github.com/devcontainers
 [@devcontainers-community]: https://github.com/devcontainers-community
 [microsoft/vscode-dev-containers]: https://github.com/microsoft/vscode-dev-containers#readme
 [devcontainers-community#1]: https://github.com/orgs/devcontainers-community/discussions/1
 [discussion]: https://github.com/devcontainers-community/templates/discussions
+[contributing guide]: https://github.com/devcontainers-community/blob/main/CONTRIBUTING.md
 <!-- prettier-ignore-end -->

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ unofficial templates!
 🐣 The [@devcontainers-community] organization is still in its early stages.
 This template repository is currently limited in scope. We are **only adding
 popular templates from [microsoft/vscode-dev-containers]** for now. You can find
-more information about [@devcontainers-community]'s goals and plans in
-[devcontainers-community#1]. If you notice a bug 🐛 or have an improvement
-suggestion 💡 we'd love to hear it! 😍
+more information about our goals and plans in [devcontainers-community#1]. If
+you notice a bug 🐛 or have an improvement suggestion 💡 we'd love to hear it!
+😍
 
 If you're interested in getting started modifying, adding, or testing a template
 in this repository, you can do so without even leaving your browser thanks to

--- a/README.md
+++ b/README.md
@@ -28,12 +28,6 @@ creation of a `.devcontainer/devcontainer.json` file!
 Make sure you click the <kbd>Show All Definitions...</kbd> option to see our
 unofficial templates!
 
-<div align="center">
-
-![](https://i.imgur.com/IO5r8Gf.png)
-
-</div>
-
 ## Development
 
 🐣 The [@devcontainers-community] organization is still in its early stages.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@
 💻 Ready to go with GitHub Codespaces \
 🚀 Quickly get up-and-running with a devcontainer
 
+**🤝 We want you!** If you're a community devcontainer template maintainer, we'd
+love to add you to this project! ❤️ If you just want to hand off a devcontainer
+template that you no longer want to maintain, **that's perfect too**. Open a
+[Discussion] and let's have a friendly chat. 😊
+
 ## Usage
 
 ![Codespaces](https://img.shields.io/static/v1?style=for-the-badge&message=Codespaces&color=181717&logo=GitHub&logoColor=FFFFFF&label=)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,37 @@
-<div align="center">
-
 ![🚧 Under construction 👷‍♂️](https://i.imgur.com/LEP2R3N.png)
 
+# Community devcontainer templates
+
+📋 Community-driven collection of templates for [@devcontainers]
+
+<div align="center">
+
+![](https://i.imgur.com/NSfVKbP.png)
+
 </div>
+
+🔧 80% of the configuration you'll ever need \
+💻 Ready to go with GitHub Codespaces \
+🚀 Quickly get up-and-running with a devcontainer \
+🐳 No need to mess with a `Dockerfile`
+
+## Usage
+
+![Codespaces](https://img.shields.io/static/v1?style=for-the-badge&message=Codespaces&color=181717&logo=GitHub&logoColor=FFFFFF&label=)
+![Devcontainers](https://img.shields.io/static/v1?style=for-the-badge&message=Devcontainers&color=2496ED&logo=Docker&logoColor=FFFFFF&label=)
+
+After creating a GitHub Codespace (or a devcontainer in VS Code), open the
+Command Palette to find the <kbd>Dev Containers: Add Dev Container Configuration
+Files...</kbd> command. After you run it, VS Code will guide you through the
+creation of a `.devcontainer/devcontainer.json` file!
+
+Make sure you click the <kbd>Show All Definitions...</kbd> option to see our
+unofficial templates!
+
+<div align="center">
+
+![](https://i.imgur.com/IO5r8Gf.png)
+
+</div>
+
+[@devcontainers]: https://github.com/devcontainers


### PR DESCRIPTION
This PR would... (checkboxes track draft progress)
- [x] Add a header image
- [x] Make sure the under construction banner stays there for a bit while longer (until at least #5 is merged)
- [x] Try to be original (right now heavily inspired by @jcbhmr's previous contributions to https://github.com/devcontainers-contrib/templates/blob/main/README.md
- [x] Add instructions on _how to use_ these templates
- [x] Add a dev section with a gist of how to fix/add stuff
- [x] Include a reference to the CONTRIBUTING.md
- [x] Encourage existing community members who have possible devcontainer templates to reach out

Other meta stuff:
- [x] Conform to commit convention?
- [x] Passes linting?