### PR TITLE
Add settings screenshot to CONTRIBUTING conventions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD041 MD036 MD033 -->
+
 **Thanks for taking the time to contribute! ❤️**
 
 All types of contributions are encouraged and valued, no matter if it's a bug
@@ -30,7 +32,7 @@ merged with the `main` branch.
 
 <div align="center">
 
-![](https://user-images.githubusercontent.com/61068799/235573284-82e555ce-ebb8-4344-80d7-2d6054386bf2.png)
+![Screenshot of PR settings](https://user-images.githubusercontent.com/61068799/235573284-82e555ce-ebb8-4344-80d7-2d6054386bf2.png)
 
 </div>
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,12 @@ This repository is sort-of like a monorepo. We use a monorepo commit convention
 where the PR title becomes the commit message of a single squashed commit when
 merged with the `main` branch.
 
+<div align="center">
+
+![](https://user-images.githubusercontent.com/61068799/235573284-82e555ce-ebb8-4344-80d7-2d6054386bf2.png)
+
+</div>
+
 This means that your PR should at least _try_ to conform to the conventional
 commits format. Usually that means something like
 "feat(jupyter-datascience-notebooks): make it work on M1 Macs". But don't worry,


### PR DESCRIPTION
This PR would...
- [x] Add a screenshot to CONTRIBUTING.md to clarify what the squash merge thing is that is being discussed

preview:
![image](https://user-images.githubusercontent.com/61068799/235573528-f00883cd-516d-4fd1-899c-adff23fcee9a.png)